### PR TITLE
correcting typo allows darwin to work

### DIFF
--- a/bodge-glfw-bindings.asd
+++ b/bodge-glfw-bindings.asd
@@ -11,4 +11,4 @@
    (:file "bindings/x86_64-w64-mingw32" :if-feature
     (:and :x86-64 :windows))
    (:file "bindings/x86_64-apple-darwin-gnu" :if-feature
-    (:and :x86-64 :drawin))))
+    (:and :x86-64 :darwin))))


### PR DESCRIPTION
Have been trying to get this to work for ages.
Your recent claw-git2 example gave me a hint where to check.
Thanks.
