### PR TITLE
ppc64le: Define window-focus callback

### DIFF
--- a/src/glfw.lisp
+++ b/src/glfw.lisp
@@ -51,6 +51,12 @@
      ,@body))
 
 
+(defmacro define-window-focus-callback (name (window iconified) &body body)
+  `(cffi:defcallback ,name :void ((,window (:pointer %glfw:window))
+                                  (,iconified :int))
+     ,@body))
+
+
 (defmacro define-char-callback (name (window codepoint) &body body)
   `(cffi:defcallback ,name :void ((,window (:pointer %glfw:window))
                                   (,codepoint :unsigned-int))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -7,6 +7,7 @@
            #:define-scroll-callback
            #:define-framebuffer-size-callback
            #:define-window-size-callback
+           #:define-window-focus-callback
            #:define-char-callback
            #:define-joystick-callback
            #:with-window-hints


### PR DESCRIPTION
I don't expect this to be merged, I'm just posting it for discussion purposes.  Only on ppc64le, not on ppc64, I need this patch, to avoid:

```
CL-USER> (ql:quickload :trivial-gamekit)
To load "trivial-gamekit":
  Load 1 ASDF system:
    trivial-gamekit
; Loading "trivial-gamekit"
....
; 
; caught ERROR:
;   READ error during COMPILE-FILE:
;   
;     Symbol "DEFINE-WINDOW-FOCUS-CALLBACK" not found in the GLFW package.
;   
;       Line: 232, Column: 34, File-Position: 8665
;   
;       Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /build/quicklisp/local-projects/bodge-host/src/window.lisp" {100644543C}>
; 
; compilation unit aborted
;   caught 2 fatal ERROR conditions
;   caught 1 ERROR condition
; Evaluation aborted on #<UIOP/LISP-BUILD:COMPILE-FILE-ERROR {100863DD9C}>.
```
